### PR TITLE
Updated dockerfiles for prysm and geth to fix problems and removed build.sh

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Build Geth container
-docker build -t stratis-geth:latest ./geth
-# Build Prysm container
-docker build -t stratis-prysm:latest ./prysm

--- a/docker/geth/Dockerfile
+++ b/docker/geth/Dockerfile
@@ -7,20 +7,20 @@ WORKDIR /usr/src/app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git make
 
+# Download Geth binary
+RUN wget https://github.com/stratisproject/go-stratis/releases/download/0.1.1/geth-linux-amd64-5c4504c.tar.gz -O geth.tar.gz && \
+    tar -xzf geth.tar.gz -C /usr/local/bin/ && \
+    rm geth.tar.gz
+
 # Clone the StratisEVM repository
-RUN git clone https://github.com/stratisproject/StratisEVM --recurse-submodules
+RUN git clone https://github.com/stratisproject/StratisEVM
 
-# Build Geth from Source
-WORKDIR /usr/src/app/StratisEVM/go-ethereum
-RUN go build -o=/usr/local/bin/geth ./cmd/geth
-
-# Initialize GETH
-WORKDIR /usr/src/app/StratisEVM
-RUN /usr/local/bin/geth --datadir=data/testnet/geth init configs/testnet/genesis.json
+# Set workdir
+WORKDIR /usr/src/app/StratisEVM/
 
 # Expose Geth ports
 EXPOSE 8545 30303
 
 # Run Geth
 ENTRYPOINT ["/usr/local/bin/geth"]
-CMD ["--datadir=data/testnet/geth", "--http", "--http.api=eth,engine,net,web3", "--http.addr=0.0.0.0", "--http.corsdomain=*", "--ws", "--ws.api=eth,engine,net,web3", "--ws.addr=0.0.0.0", "--ws.origins=*", "--authrpc.vhosts=*", "--authrpc.addr=0.0.0.0", "--authrpc.jwtsecret=configs/testnet/jwtsecret", "--syncmode=full"]
+CMD ["--datadir=data/testnet/geth", "--auroria" ,"--http", "--http.api=eth,engine,net,web3", "--http.addr=0.0.0.0", "--http.corsdomain=*", "--ws", "--ws.api=eth,engine,net,web3", "--ws.addr=0.0.0.0", "--ws.origins=*", "--authrpc.vhosts=*", "--authrpc.addr=0.0.0.0", "--authrpc.jwtsecret=configs/testnet/jwtsecret", "--syncmode=full"]

--- a/docker/prysm/Dockerfile
+++ b/docker/prysm/Dockerfile
@@ -7,17 +7,20 @@ WORKDIR /usr/src/app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git make
 
-# Clone the StratisEVM repository
-RUN git clone https://github.com/stratisproject/StratisEVM --recurse-submodules
+# Download Prysm binary
+RUN wget https://github.com/stratisproject/prysm-stratis/releases/download/0.1.1/beacon-chain-linux-amd64-0ebd251.tar.gz -O beacon-chain.tar.gz && \
+    tar -xzf beacon-chain.tar.gz -C /usr/local/bin/ && \
+    rm beacon-chain.tar.gz
 
-# Build Prysm from Source
-WORKDIR /usr/src/app/StratisEVM/prysm-stratis
-RUN go build -o=/usr/local/bin/beacon-chain ./cmd/beacon-chain
+# Clone the StratisEVM repository
+RUN git clone https://github.com/stratisproject/StratisEVM
+
+# Set workdir
+WORKDIR /usr/src/app/StratisEVM
 
 # Expose Prysm ports
 EXPOSE 4000 13000 12000/udp
 
 # Run Prysm
-WORKDIR /usr/src/app/StratisEVM
 ENTRYPOINT ["/usr/local/bin/beacon-chain"]
-CMD ["--p2p-static-id", "--datadir=data/testnet/beacon", "--rpc-host=0.0.0.0", "--grpc-gateway-host=0.0.0.0", "--execution-endpoint=http://localhost:8551", "--accept-terms-of-use", "--jwt-secret=configs/testnet/jwtsecret", "--suggested-fee-recipient=0x123463a4B065722E99115D6c222f267d9cABb524", "--minimum-peers-per-subnet=0", "--enable-debug-rpc-endpoints"]
+CMD ["--p2p-static-id", "--datadir=data/testnet/beacon", "--auroria", "--rpc-host=0.0.0.0", "--grpc-gateway-host=0.0.0.0", "--execution-endpoint=http://geth:8551", "--accept-terms-of-use", "--jwt-secret=configs/testnet/jwtsecret", "--suggested-fee-recipient=0x123463a4B065722E99115D6c222f267d9cABb524", "--minimum-peers-per-subnet=0", "--enable-debug-rpc-endpoints"]


### PR DESCRIPTION
Updated execution endpoint address for prysm, download binaries for geth and prysm instead of building from source.
Removed docker/build.sh script, since there is "docker-compose build" command doing same thing.